### PR TITLE
Add importlib-metadata dependency for python<3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Development: https://github.com/intake/filesystem_spec
 
 Documentation: https://filesystem-spec.readthedocs.io
 
+To produce a template or specification for a file-system interface, that specific implementations should follow, so that applications making use of them can rely on a common behaviour and not have to worry about the specific internal implementation decisions with any given backend. Many such implementations are included in this package, or in sister projects such as s3fs and gcsfs.
+In addition, if this is well-designed, then additional functionality, such as a key-value store or FUSE mounting of the file-system implementation may be available for all implementations "for free".
+
+
 Current build status
 ====================
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,6 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
   patches:
@@ -16,7 +15,7 @@ source:
 build:
   number: 1
   noarch: python
-  script: {{ PYTHON }}  -m pip install . --no-deps --ignore-installed -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
 
 requirements:
   host:
@@ -27,8 +26,14 @@ requirements:
     - python >=3.5
 
 test:
+  requires:
+    - pip
+    # TODO: remove, probably
+    - python <3.8
   imports:
     - fsspec
+  commands:
+    - pip check
 
 about:
   home: https://github.com/intake/filesystem_spec
@@ -37,6 +42,18 @@ about:
   summary: A specification for pythonic filesystems
   dev_url: https://github.com/intake/filesystem_spec
   doc_url: https://filesystem-spec.readthedocs.io
+  doc_source_url: https://github.com/intake/filesystem_spec/tree/master/docs
+  description: >
+    To produce a template or specification for a file-system interface, that
+    specific implementations should follow, so that applications making use of
+    them can rely on a common behaviour and not have to worry about the specific
+    internal implementation decisions with any given backend. Many such
+    implementations are included in this package, or in sister projects such as
+    s3fs and gcsfs.
+
+    In addition, if this is well-designed, then additional functionality, such
+    as a key-value store or FUSE mounting of the file-system implementation may
+    be available for all implementations "for free".
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - jinja2
   run:
     - python >=3.5
+    - importlib-metadata  # [py<38]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,8 @@ source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    - patches/0001-Make-metadata-dep-an-exrta.patch
 
 build:
   number: 1
@@ -23,7 +25,6 @@ requirements:
     - jinja2
   run:
     - python >=3.5
-    - importlib-metadata  # [py<38]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,8 +28,6 @@ requirements:
 test:
   requires:
     - pip
-    # TODO: remove, probably
-    - python <3.8
   imports:
     - fsspec
   commands:

--- a/recipe/patches/0001-Make-metadata-dep-an-exrta.patch
+++ b/recipe/patches/0001-Make-metadata-dep-an-exrta.patch
@@ -1,0 +1,25 @@
+From 131fc374dc03edeaf12f8a594bb50db4d8d141be Mon Sep 17 00:00:00 2001
+From: Martin Durant <martin.durant@utoronto.ca>
+Date: Thu, 8 Apr 2021 11:58:33 -0400
+Subject: [PATCH] Make metadata dep an exrta
+
+---
+ setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index b51f0fa..18b7b48 100644
+--- a/setup.py
++++ b/setup.py
+@@ -35,7 +35,7 @@ setup(
+     python_requires=">=3.6",
+     install_requires=open("requirements.txt").read().strip().split("\n"),
+     extras_require={
+-        ":python_version < '3.8'": ["importlib_metadata"],
++        "entrypoints": ["importlib_metadata ; python_version < '3.8' "],
+         "abfs": ["adlfs"],
+         "adl": ["adlfs"],
+         "dask": ["dask", "distributed"],
+-- 
+2.27.0
+


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes #42 
<!--
Please add any other relevant info below:
-->

importlib-metadata is a dependency that is not required from Python 3.8 onward since then it is already part of Python itself. However, to avoid problems, particularly with entry_point resolution in downstream packages, it should be added as a dependency for older Python versions.