### PR TITLE
Add `aiohttp` as a run dependency

### DIFF
--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -12,7 +12,7 @@ source .scripts/logging_utils.sh
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
-PROVIDER_DIR="$(basename $THISDIR)"
+PROVIDER_DIR="$(basename "$THISDIR")"
 
 FEEDSTOCK_ROOT="$( cd "$( dirname "$0" )/.." >/dev/null && pwd )"
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"

--- a/build-locally.py
+++ b/build-locally.py
@@ -10,6 +10,7 @@ import glob
 import os
 import platform
 import subprocess
+import sys
 from argparse import ArgumentParser
 
 
@@ -44,10 +45,19 @@ def run_osx_build(ns):
     subprocess.check_call([script])
 
 
+def run_win_build(ns):
+    script = ".scripts/run_win_build.bat"
+    subprocess.check_call(["cmd", "/D", "/Q", "/C", f"CALL {script}"])
+
+
 def verify_config(ns):
+    choices_filter = ns.filter or "*"
     valid_configs = {
-        os.path.basename(f)[:-5] for f in glob.glob(".ci_support/*.yaml")
+        os.path.basename(f)[:-5]
+        for f in glob.glob(f".ci_support/{choices_filter}.yaml")
     }
+    if choices_filter != "*":
+        print(f"filtering for '{choices_filter}.yaml' configs")
     print(f"valid configs are {valid_configs}")
     if ns.config in valid_configs:
         print("Using " + ns.config + " configuration")
@@ -60,30 +70,37 @@ def verify_config(ns):
         selections = list(enumerate(sorted(valid_configs), 1))
         for i, c in selections:
             print(f"{i}. {c}")
-        s = input("\n> ")
+        try:
+            s = input("\n> ")
+        except KeyboardInterrupt:
+            print("\nno option selected, bye!", file=sys.stderr)
+            sys.exit(1)
         idx = int(s) - 1
         ns.config = selections[idx][1]
         print(f"selected {ns.config}")
     else:
         raise ValueError("config " + ns.config + " is not valid")
-    # Remove the following, as implemented
-    if ns.config.startswith("win"):
-        raise ValueError(
-            f"only Linux/macOS configs currently supported, got {ns.config}"
+    if (
+        ns.config.startswith("osx")
+        and platform.system() == "Darwin"
+        and not os.environ.get("OSX_SDK_DIR")
+    ):
+        raise RuntimeError(
+            "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+            "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+            "Note: OSX_SDK_DIR must be set to an absolute path. "
+            "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
         )
-    elif ns.config.startswith("osx"):
-        if "OSX_SDK_DIR" not in os.environ:
-            raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
-                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
-                "Note: OSX_SDK_DIR must be set to an absolute path. "
-                "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
-            )
 
 
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--filter",
+        default=None,
+        help="Glob string to filter which build choices are presented in interactive mode.",
+    )
     p.add_argument(
         "--debug",
         action="store_true",
@@ -104,6 +121,8 @@ def main(args=None):
             run_docker_build(ns)
         elif ns.config.startswith("osx"):
             run_osx_build(ns)
+        elif ns.config.startswith("win"):
+            run_win_build(ns)
     finally:
         recipe_license_file = os.path.join(
             "recipe", "recipe-scripts-license.txt"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - hatch-vcs
   run:
     - python >={{ python_min }}
+    - aiohttp <4
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,14 +13,13 @@ source:
 build:
   number: 1
   noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - python {{ python_min }}
     - pip
-    - jinja2
-    - hatch
+    - hatchling
     - hatch-vcs
   run:
     - python >={{ python_min }}
@@ -28,8 +27,8 @@ requirements:
 
 test:
   requires:
-    - pip
     - python {{ python_min }}
+    - pip
   imports:
     - fsspec
   commands:


### PR DESCRIPTION
This PR adds [`aiohttp`](https://docs.aiohttp.org/en/stable/) as a run dependency.

`fsspec` has a optional `aiohttp` dependency. Conda still doesn't support optional dependencies ([although this might change in the future](https://prefix.dev/blog/ceps_2025#optional-dependencies-conditional-dependencies-and-flags)), but by omitting `aiohttp` from the Conda build recipes that depend on `fsspec[http]` are failing (see example [here](https://github.com/conda-forge/euporie-feedstock/pull/55)).

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
